### PR TITLE
Start goblin core properly

### DIFF
--- a/bin/host
+++ b/bin/host
@@ -75,6 +75,8 @@ class Host {
 
     yield next.sync();
 
+    yield this._busClient.command.send('goblin.start', null, null, next);
+
     /* Start the main quest (app bootstrap). */
     yield this._busClient.command.send(
       this._xConfig.mainQuest,


### PR DESCRIPTION
It's not possible to use the _postload command because
the start must be done with the current host busClient.