### PR TITLE
Add helpers from goblin-vm to WindowManager class

### DIFF
--- a/lib/wm.js
+++ b/lib/wm.js
@@ -6,7 +6,7 @@ const watt = require('gigawatts');
 
 class Window {
   constructor(wm, options) {
-    const {BrowserWindow, screen} = require('electron');
+    const {BrowserWindow} = require('electron');
     //copy config
     this.wm = wm;
     this.winOptions = {...this.wm.config.windowOptions};
@@ -22,29 +22,6 @@ class Window {
       nodeIntegration: true,
       contextIsolation: false,
     };
-
-    if (!this.winOptions.width && !this.winOptions.height) {
-      const point = screen.getCursorScreenPoint();
-      const {workArea} = screen.getDisplayNearestPoint(point);
-
-      // Use 80% of work area
-      const factor = 0.8;
-      let width = workArea.width * factor;
-      let height = workArea.height * factor;
-      // If the window is smaller than 1280x720, use 100% of work area
-      if (width < 1280 || height < 720) {
-        width = workArea.width;
-        height = workArea.height;
-      }
-      this.winOptions.width = parseInt(width);
-      this.winOptions.height = parseInt(height);
-      this.winOptions.x = parseInt(
-        workArea.x + workArea.width / 2 - this.winOptions.width / 2
-      );
-      this.winOptions.y = parseInt(
-        workArea.y + workArea.height / 2 - this.winOptions.height / 2
-      );
-    }
 
     //VIBRANCY SUPPORT
     /*let vibrancy;
@@ -109,16 +86,12 @@ class Window {
   setState(windowState) {
     if (windowState) {
       //TODO: invalidate bad bounds
-      this.win.setPosition(
-        windowState.get('bounds.x'),
-        windowState.get('bounds.y'),
-        true
-      );
-      this.win.setSize(
-        windowState.get('bounds.width'),
-        windowState.get('bounds.height'),
-        true
-      );
+      this.win.setBounds({
+        x:windowState.get('bounds.x'),
+        y:windowState.get('bounds.y'),
+        height:windowState.get('bounds.height'),
+        width:windowState.get('bounds.width'),
+      },true);
     }
   }
 
@@ -198,6 +171,55 @@ class WindowManager {
       this.displaySplash();
     }
     watt.wrapAll(this);
+  }
+
+  getDefaultWindowState() {
+    return {
+      bounds: this.getDefaultWindowBounds(),
+      maximized: false,
+      fullscreen: false,
+    };
+  }
+
+  getDefaultWindowBounds() {
+    const {screen} = require('electron');
+    const point = screen.getCursorScreenPoint();
+    const {x, y, width, height} = screen.getDisplayNearestPoint(point).workArea;
+    // Use 80% of work area
+    const factor = 0.8;
+    let bounds = {
+      x,
+      y,
+      width: width * factor, 
+      height: height * factor
+    };
+    // If the window is smaller than 1280x720, use 100% of work area
+    if (bounds.width < 1280 || bounds.height < 720) {
+      bounds.width = width;
+      bounds.height = height;
+    }
+    bounds.width = parseInt(bounds.width);
+    bounds.height = parseInt(bounds.height);
+    // Center window on current display
+    bounds.x = parseInt(
+      x + width / 2 - bounds.width / 2
+    );
+    bounds.y = parseInt(
+      y + height / 2 - bounds.height / 2
+    );
+    return bounds;
+  }
+
+  getWindowState(window) {
+    if (window && window.isDestroyed()) {
+      return null;
+    }
+    let bounds = window.getNormalBounds();
+    return {
+      bounds,
+      maximized: window.isMaximized(),
+      fullscreen: window.isFullScreen(),
+    };
   }
 
   get currentWindow() {


### PR DESCRIPTION
Fix a case where we create a window on first display and move it to a second display with different scale factor.

Electron isn't handling properly setBounds/setPosition or setSize in this case. Creating window directly on the right screen avoid this issue.

https://github.com/electron/electron/issues/10862